### PR TITLE
Fix unit test

### DIFF
--- a/harbinger/tests/test_base.py
+++ b/harbinger/tests/test_base.py
@@ -24,7 +24,7 @@ class TestBase(unittest.TestCase):
         self.assertRaises(IOError, base.harbingeropts, '')
 
     def test_harbingeropts_success(self):
-        self.assertGreater(base.OPTS, 0)
+        self.assertGreater(len(base.OPTS), 0)
         original_opts = copy.deepcopy(base.OPTS)
         base.OPTS = []
         self.assertEqual(len(base.OPTS), 0)


### PR DESCRIPTION
Currently, there is a test that compares a list (.OPTS) to an integer (0).
This comparison is causing an error when the unit test is run.  This patch
set now compares the length of the list to 0 instead.

Signed-off-by: Tin Lam <tin@irrational.io>