### PR TITLE
Add unit tests for directory_manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Harbinger
 Modular manager for Openstack data plane testing frameworks
 
 Harbinger  allows execution of various Openstack data plane testing frameworks 
-while maintainting a single standardized interfance and input format
+while maintainting a single standardized interface and input format
 
 Documentation can be found at
 https://harbinger-dpm.readthedocs.io/en/latest/ 

--- a/harbinger/tests/common/test_directory_manager.py
+++ b/harbinger/tests/common/test_directory_manager.py
@@ -1,0 +1,8 @@
+# This Python file uses the following encoding: utf-8
+
+import unittest
+
+from harbinger.common import directory_manager
+
+class DirectoryManagerTest(unittest.TestCase):
+    pass

--- a/harbinger/tests/common/test_directory_manager.py
+++ b/harbinger/tests/common/test_directory_manager.py
@@ -1,8 +1,34 @@
-# This Python file uses the following encoding: utf-8
-
+import argparse
 import unittest
 
-from harbinger.common import directory_manager
+import mock
 
-class DirectoryManagerTest(unittest.TestCase):
-    pass
+from harbinger.base import Base  # noqa
+from harbinger.common.directory_manager import \
+    DirectoryManager
+
+
+class TestDirectoryManager(unittest.TestCase):
+
+    def setUp(self):
+        self.args = mock.Mock(spec=argparse.Namespace)
+        self.test_object = DirectoryManager()
+
+    @mock.patch('harbinger.common.directory_manager.os', autospec=True)
+    def test_setup(self, mock_os):
+        mock_os.path.isdir.return_value = False
+
+        self.test_object.setup()
+
+        calls = [
+            mock.call(self.test_object.inputs_dir),
+            mock.call(self.test_object.outputs_dir)
+        ]
+
+        mock_os.path.isdir.assert_has_calls(calls)
+        mock_os.makedirs.assert_has_calls(calls)
+
+    @mock.patch('harbinger.common.directory_manager.os', autospec=True)
+    def test_archive_outputs(self, mock_os):
+        self.test_object.setup()
+        self.test_object.archive_outputs()

--- a/harbinger/tests/common/test_directory_manager.py
+++ b/harbinger/tests/common/test_directory_manager.py
@@ -29,6 +29,33 @@ class TestDirectoryManager(unittest.TestCase):
         mock_os.makedirs.assert_has_calls(calls)
 
     @mock.patch('harbinger.common.directory_manager.os', autospec=True)
+    def test_setup_bad_dirs(self, mock_os):
+        mock_os.makedirs.side_effect = OSError
+
+        self.test_object.setup()
+
+        self.assertRaises(OSError)
+
+    @mock.patch('harbinger.common.directory_manager.os', autospec=True)
     def test_archive_outputs(self, mock_os):
         self.test_object.setup()
-        self.test_object.archive_outputs()
+
+        mock_os.walk.return_value = [
+            ('.', ['dir1'], ['file1'])
+        ]
+
+        with mock.patch("__builtin__.open",
+                        mock.mock_open(read_data="data")) as mock_file:
+            self.test_object.archive_outputs()
+            self.assertEqual(open("path/to/open").read(), "data")
+            mock_file.assert_called_with("path/to/open")
+
+    @mock.patch('harbinger.common.directory_manager.os', autospec=True)
+    def test_archive_outputs_bad(self, mock_os):
+        self.test_object.setup()
+
+        mock_os.walk.return_value = []
+
+        with mock.patch("__builtin__.open") as mock_file:
+            self.test_object.archive_outputs()
+            mock_file.assert_not_called()


### PR DESCRIPTION
Added 4 unit tests for directory_manager.py and increased code coverage to 100%.

Also fixed a typo in the README.